### PR TITLE
【FIN】[staging -> main]: Replace a displayed-wallet address in a notification of the `"Email already associated with address xxx"`(= `"A given nullifierHash is already used"`) with a `_walletAddressFromOnChain` (icl. PR#58)

### DIFF
--- a/miniapp-base/src/components/SignInPanel.tsx
+++ b/miniapp-base/src/components/SignInPanel.tsx
@@ -206,7 +206,16 @@ export function SignInPanel() { // @dev - For Wagmi
           toast.dismiss(toastToNotifyZkJwtPublicInputsRecordingOnChain); // @dev - Dismiss the previous notification about the beginning of public inputs recording on-chain.
           console.error('Error when a given public inputs is recorded on-chain (BASE):', error);
           if (extractErrorMessageInString(error) && error.message.includes("A given nullifierHash is already used, which means a given proof is already used")) {
-            toast.error(`Email already associated with address ${ truncateAddress(walletAddressFromConnectedWallet) }. Please connect with the same address to log in`);
+            // @dev - Get public inputs from on-chain
+            const publicInputsFromOnChain: PublicInputs = await readContract(wagmiConfig, {
+                abi: zkJwtProofManagerAbi,
+                address: zkJwtProofManagerContractAddress as `0x${string}`,
+                functionName: 'getPublicInputsOfZkJwtProof',
+                args: [nullifierFromZkJwtCircuit]
+            }) as PublicInputs;
+            //console.log(`publicInputs (from on-chain): ${JSON.stringify(publicInputsFromOnChain, null, 2)}`);
+            const _walletAddressFromOnChain: string = publicInputsFromOnChain.walletAddress;
+            toast.error(`Email already associated with address ${ truncateAddress(_walletAddressFromOnChain) }. Please connect with the same address to log in`);
           } else if (extractErrorMessageInString(error) && error.message.includes("User rejected the request")) {
             toast.error(`Cancelled the transaction`);
           } else if (extractErrorMessageInString(error) && error.message.includes("insufficient funds for gas")) {


### PR DESCRIPTION
This PR is for reflecting the PR #58 to the main branch / production environment.