### PR TITLE
[FE - Notification]: Switch the `toast.error` to the `console.error()` for the error message of the `"when a given public inputs is recorded on-chain (BASE):"`

### DIFF
--- a/miniapp-base/src/components/SignInPanel.tsx
+++ b/miniapp-base/src/components/SignInPanel.tsx
@@ -204,7 +204,7 @@ export function SignInPanel() { // @dev - For Wagmi
           }
         } catch (error: unknown) {
           toast.dismiss(toastToNotifyZkJwtPublicInputsRecordingOnChain); // @dev - Dismiss the previous notification about the beginning of public inputs recording on-chain.
-          console.error('Error when a given public inputs is recorded on-chain (BASE):', error);
+          //console.error('Error when a given public inputs is recorded on-chain (BASE):', error);
           if (extractErrorMessageInString(error) && error.message.includes("A given nullifierHash is already used, which means a given proof is already used")) {
             // @dev - Get public inputs from on-chain
             const publicInputsFromOnChain: PublicInputs = await readContract(wagmiConfig, {

--- a/miniapp-base/src/components/SignInPanel.tsx
+++ b/miniapp-base/src/components/SignInPanel.tsx
@@ -221,7 +221,8 @@ export function SignInPanel() { // @dev - For Wagmi
           } else if (extractErrorMessageInString(error) && error.message.includes("insufficient funds for gas")) {
             toast.error(`Insufficient funds for gas`);
           } else {
-            toast.error(`when a given public inputs is recorded on-chain (BASE): ${extractErrorMessageInString(error)}`);
+            toast.error(`Failed to send a transaction to blockchain`);
+            console.error(`when a given public inputs is recorded on-chain (BASE): ${extractErrorMessageInString(error)}`);
             //toast.error(`when a given public inputs is recorded on-chain (BASE): ${(error as any).message}`);
           }
         }
@@ -265,9 +266,8 @@ export function SignInPanel() { // @dev - For Wagmi
     } catch (err: unknown) {
       console.error('Error in the SignInPanel:', err);
       if (extractErrorMessageInString(err)) {
-        toast.error(`Error: ${extractErrorMessageInString(err)}`);
-      } else {
         toast.error("Failed to authenticate with Google");
+        console.error(`Error: ${extractErrorMessageInString(err)}`);
       }
       setError('Failed to authenticate with Google');
     } finally {


### PR DESCRIPTION
# Target notification to be fixed

<img width="294" height="61" alt="Screenshot 2025-09-25 at 9 48 13" src="https://github.com/user-attachments/assets/eec06c74-cfd7-427d-9e3a-abecfb3c5f8a" />
